### PR TITLE
Update Gemfile and Gemfile.lock to support Ruby 3.4+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ source "https://rubygems.org"
 # gem "rails"
 gem 'selenium-webdriver', '4.1.0'
 gem 'browserstack-local', '1.3.0'
+gem 'base64', '0.2.0'
+gem "logger", '1.6.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,27 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.2.0)
     browserstack-local (1.3.0)
     childprocess (4.1.0)
-    rexml (3.2.5)
-    rubyzip (2.3.2)
+    logger (1.6.5)
+    rexml (3.4.0)
+    rubyzip (2.4.1)
     selenium-webdriver (4.1.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2)
 
 PLATFORMS
+  arm64-darwin-24
+  ruby
   x86_64-darwin-20
 
 DEPENDENCIES
+  base64 (= 0.2.0)
   browserstack-local (= 1.3.0)
+  logger (= 1.6.5)
   selenium-webdriver (= 4.1.0)
 
 BUNDLED WITH
-   2.2.3
+   2.6.2


### PR DESCRIPTION
base64 is no longer in standard library as of 3.4
logger will be removed from standard library in 3.5